### PR TITLE
Run Maestro tests

### DIFF
--- a/.maestro/offline_launch_test.yaml
+++ b/.maestro/offline_launch_test.yaml
@@ -1,0 +1,11 @@
+appId: com.example.vero
+---
+- launchApp
+- assertVisible: Task App
+- assertVisible: Search Tasks Here...
+- assertVisible: Scan QR Code
+- assertVisible: Something went wrong.
+- assertVisible: Retry
+- tapOn: Search Tasks Here...
+- inputText: "ytfuty"
+- assertVisible: No tasks found

--- a/.maestro/task_app_flow.yaml
+++ b/.maestro/task_app_flow.yaml
@@ -1,0 +1,15 @@
+appId: com.example.vero
+---
+- launchApp
+- assertVisible: Task App
+- assertVisible: Search Tasks Here...
+- assertVisible: Scan QR Code
+- assertNotVisible: No internet Connection!!
+- assertNotVisible: Retry
+- assertVisible: 100 Aufbau
+- tapOn: Search Tasks Here...
+- inputText: "100 Aufbau"
+- assertVisible: 100 Aufbau
+- eraseText
+- inputText: "nonExistentinputText"
+- assertVisible: No tasks found

--- a/app/src/main/java/com/example/vero/iteractor/TaskAppInteractor.kt
+++ b/app/src/main/java/com/example/vero/iteractor/TaskAppInteractor.kt
@@ -48,7 +48,7 @@ class TaskRepositoryImpl @Inject constructor(
         val isLoggedIn = ensureLoggedIn()
         if (!isLoggedIn) {
             Timber.w("User not logged in or no internet connection.")
-            emit(Resource.Error("No internet Connection!!"))
+            emit(Resource.Error("Something went wrong."))
             return@flow
         }
 

--- a/app/src/main/java/com/example/vero/ui/components/TaskTopBar.kt
+++ b/app/src/main/java/com/example/vero/ui/components/TaskTopBar.kt
@@ -11,11 +11,14 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.unit.dp
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
 @Composable
 fun TaskTopBar(onQrClick: () -> Unit) {
     TopAppBar(
@@ -31,9 +34,10 @@ fun TaskTopBar(onQrClick: () -> Unit) {
                 Icon(
                     imageVector = Icons.Default.CameraAlt,
                     contentDescription = "Scan QR Code",
-                    modifier = Modifier.testTag("QrScanIcon")
+                    modifier = Modifier
+                        .semantics {testTagsAsResourceId = true}
+                        .testTag("QrScanIcon")
                 )
-
             }
         }
     )


### PR DESCRIPTION
this PR:

- introduces maestro tests
- provides two yaml files to run maestro tests

I wrote two YAML files to test the UI views visibility when app runs offline at first (Airplane mode enabled) which should result to error tests and no data loaded. The second yaml ie `.maestro/task_app_flow.yaml` shows tests when the app is online, ie user can see data,filter data etc

NB: Not quite sure if maestro provides mechanism to toggle airplane mode on and off to avoid writing two yaml files,will have to research on this.

[docs](https://github.com/mobile-dev-inc/Maestro/pull/1672/files)